### PR TITLE
fix: move load_dotenv to module level and guard scrape_page against missing elements

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -9,6 +9,9 @@ from playwright.sync_api import sync_playwright
 import schedule
 import time
 
+# Load .env before reading any env vars so user-configured values take effect.
+load_dotenv()
+
 DB_PATH = os.getenv('DB_PATH', 'prices.db')
 BASE_URL = 'https://books.toscrape.com/catalogue/'
 EXPORT_DIR = os.getenv('EXPORT_DIR', 'exports')
@@ -47,9 +50,17 @@ def scrape_page(page):
     items = []
     cards = page.query_selector_all('.product_pod')
     for card in cards:
-        title = card.query_selector('h3 a').get_attribute('title')
-        price_text = card.query_selector('.price_color').inner_text()
-        rating = card.query_selector('.star-rating').get_attribute('class').replace('star-rating ', '')
+        title_el = card.query_selector('h3 a')
+        price_el = card.query_selector('.price_color')
+        rating_el = card.query_selector('.star-rating')
+
+        if not title_el or not price_el or not rating_el:
+            # Incomplete card — skip rather than crash the whole scrape run.
+            continue
+
+        title = title_el.get_attribute('title')
+        price_text = price_el.inner_text()
+        rating = rating_el.get_attribute('class').replace('star-rating ', '')
         items.append({
             'title': title,
             'price': parse_price(price_text),
@@ -109,7 +120,6 @@ def send_email(report_path):
 
 
 def run_scrape():
-    load_dotenv()
     conn = sqlite3.connect(DB_PATH)
     init_db(conn)
 


### PR DESCRIPTION
## Summary

Two bugs fixed in a single pass — both are in `scraper.py` and tightly related to startup correctness.

---

### Bug 1 — `load_dotenv()` called too late (Issue #7)

`DB_PATH` and `EXPORT_DIR` are module-level constants:

```python
DB_PATH = os.getenv('DB_PATH', 'prices.db')   # line 12
EXPORT_DIR = os.getenv('EXPORT_DIR', 'exports') # line 14
```

These are evaluated **at import time**, but `load_dotenv()` was only called inside `run_scrape()` — far too late. Any value the user set in `.env` for `DB_PATH` or `EXPORT_DIR` was silently ignored; the hardcoded defaults always won.

**Fix:** move `load_dotenv()` to module level, immediately before the constant assignments. Remove the now-redundant call inside `run_scrape()`.

---

### Bug 2 — `scrape_page()` crashes on incomplete product cards (Issue #7)

`page.query_selector()` returns `None` when the selector doesn't match. The original code chained `.inner_text()` and `.get_attribute()` directly on the result with no guard:

```python
price_text = card.query_selector('.price_color').inner_text()  # AttributeError if None
```

A single malformed or partially-loaded card would raise `AttributeError` and abort the entire scrape run, losing all data collected so far.

**Fix:** assign each selector result to a variable, check for `None`, and `continue` (skip the card) rather than crashing.

---

## Testing

- Existing `test_parse_price_handles_sale_text` continues to pass unchanged.
- `scraper.py` imports cleanly with `load_dotenv()` at module level.

Closes #7