### PR TITLE
fix: call init_db before save_to_db in test_save_to_db_inserts_rows

### DIFF
--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,5 +1,5 @@
 import sqlite3
-from scraper import parse_price, save_to_db
+from scraper import init_db, parse_price, save_to_db
 
 
 def test_parse_price_handles_sale_text():
@@ -10,6 +10,7 @@ def test_parse_price_handles_sale_text():
 def test_save_to_db_inserts_rows(tmp_path):
     db_path = tmp_path / 'test.db'
     conn = sqlite3.connect(db_path)
+    init_db(conn)  # create the prices table before inserting
     items = [
         {'title': 'Book A', 'price': 9.99, 'rating': 'Three', 'scraped_at': '2024-01-01T00:00:00Z'},
         {'title': 'Book B', 'price': 12.50, 'rating': 'Five', 'scraped_at': '2024-01-01T00:05:00Z'},


### PR DESCRIPTION
## Summary

`test_save_to_db_inserts_rows` was broken — it would always fail with:

```
sqlite3.OperationalError: no such table: prices
```

### Root cause

The test creates a fresh SQLite connection via `sqlite3.connect()` and immediately calls `save_to_db()`. But `save_to_db()` does a bare `INSERT INTO prices ...` — it assumes the table already exists. The test never called `init_db()` to create the schema first.

The production path in `run_scrape()` always calls `init_db(conn)` before `save_to_db()`, so the bug only manifested in the test.

### Fix

Import `init_db` and call it on the test connection before inserting rows. One line added, zero behaviour change in production code.

Closes #8